### PR TITLE
Fix: block display on mobile

### DIFF
--- a/bot_commands/lottery.py
+++ b/bot_commands/lottery.py
@@ -87,7 +87,7 @@ async def show_votes(ctx: discord.ext.commands.context.Context):
         await ctx.send(f"No one has votes yet. Be the first!")
     else:
         message = '\n'.join([f"{name:<20} voted {vote.capitalize()}" for name, vote in vote_data])
-        message = "```" + message + "```"
+        message = "```\n" + message + "\n```"
         await ctx.send(message)
         print("Voting list showed")
     return
@@ -96,7 +96,7 @@ async def show_languages(ctx: discord.ext.commands.context.Context):
     languages = database.conn.execute(
         '''SELECT language FROM language_image_usage GROUP BY language;''').fetchall()
     message = '\n'.join([f"{i} {lang[0]}" for i, lang in enumerate(languages)])
-    message = "```" + message + "```"
+    message = "```\n" + message + "\n```"
     await ctx.send(message)
     print("Languages list showed")
     return


### PR DESCRIPTION
Fixed the display of block messages on mobile.

<table>
<tr>
<td>
Before: 
</td>
<td>
After: 
</td>
</tr>
<tr><td><img src="https://user-images.githubusercontent.com/57665730/184977873-62da4e7b-e3c5-45a3-a6d8-6e7fc16bb778.png" height="400"></td>
<td><img src="https://user-images.githubusercontent.com/57665730/184977757-1a12f474-1cc2-4648-9ee1-4cdc00eb8dbd.png" height="400"></td></tr>
</table>